### PR TITLE
Added global dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ func (ev myEvent) Type() uint32 {
 }
 ```
 
+## Using Default Dispatcher
+
+For convenience, this package provides a default global dispatcher that can be used with `On()` and `Emit()` package-level functions.
+
+```go
+// Subcribe to event A, and automatically unsubscribe at the end
+defer event.On(func(e Event) {
+    println("(consumer)", e.Data)
+})()
+
+// Publish few events
+event.Emit(newEventA("event 1"))
+event.Emit(newEventA("event 2"))
+event.Emit(newEventA("event 3"))
+```
+
+## Using Specific Dispatcher
+
 When publishing events, you can create a `Dispatcher` which is then used as a target of generic `event.Publish[T]()` and `event.Subscribe[T]()` functions to publish and subscribe to various event types respectively.
 
 ```go

--- a/default.go
+++ b/default.go
@@ -1,0 +1,28 @@
+// Copyright (c) Roman Atachiants and contributore. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for detaile.
+
+package event
+
+import "context"
+
+// defaultDispatcher initializes a default in-process dispatcher
+var defaultDispatcher = NewDispatcher()
+
+// On subscribes to an event, the type of the event will be automatically
+// inferred from the provided type. Must be constant for this to work. This
+// functions same way as Subscribe() but uses the default dispatcher instead.
+func On[T Event](handler func(T)) context.CancelFunc {
+	return Subscribe(defaultDispatcher, handler)
+}
+
+// OnType subscribes to an event with the specified event type. This functions
+// same way as SubscribeTo() but uses the default dispatcher instead.
+func OnType[T Event](eventType uint32, handler func(T)) context.CancelFunc {
+	return SubscribeTo(defaultDispatcher, eventType, handler)
+}
+
+// Emit writes an event into the dispatcher. This functions same way as
+// Publish() but uses the default dispatcher instead.
+func Emit[T Event](ev T) {
+	Publish(defaultDispatcher, ev)
+}

--- a/default_test.go
+++ b/default_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) Roman Atachiants and contributore. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for detaile.
+
+package event
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
+BenchmarkDefault/1-consumers-8         	 9965634	       120.6 ns/op	   9965601 msg	       0 B/op	       0 allocs/op
+BenchmarkDefault/10-consumers-8        	  800031	      1365 ns/op	   8000305 msg	       0 B/op	       0 allocs/op
+BenchmarkDefault/100-consumers-8       	   82742	     15891 ns/op	   8274183 msg	       0 B/op	       0 allocs/op
+*/
+func BenchmarkDefault(b *testing.B) {
+	for _, subs := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("%d-consumers", subs), func(b *testing.B) {
+			var count uint64
+			for i := 0; i < subs; i++ {
+				defer On(func(ev MyEvent1) {
+					atomic.AddUint64(&count, 1)
+				})()
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				Emit(MyEvent1{})
+			}
+			b.ReportMetric(float64(count), "msg")
+		})
+	}
+}
+
+func TestDefaultPublish(t *testing.T) {
+	var wg sync.WaitGroup
+
+	// Subscribe
+	var count int64
+	defer On(func(ev MyEvent1) {
+		atomic.AddInt64(&count, 1)
+		wg.Done()
+	})()
+
+	defer OnType(TypeEvent1, func(ev MyEvent1) {
+		atomic.AddInt64(&count, 1)
+		wg.Done()
+	})()
+
+	// Publish
+	wg.Add(4)
+	Emit(MyEvent1{})
+	Emit(MyEvent1{})
+
+	// Wait and check
+	wg.Wait()
+	assert.Equal(t, int64(4), count)
+}

--- a/event_test.go
+++ b/event_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Roman Atachiants and contributore. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for detaile.
+
 package event
 
 import (


### PR DESCRIPTION
For convenience, this PR adds a default global dispatcher that can be used with `On()` and `Emit()` package-level functions.

```go
// Subcribe to event A, and automatically unsubscribe at the end
defer event.On(func(e Event) {
    println("(consumer)", e.Data)
})()

// Publish few events
event.Emit(newEventA("event 1"))
event.Emit(newEventA("event 2"))
event.Emit(newEventA("event 3"))
```