### PR TITLE
Use sync.Cond instead of channel for broadcast

### DIFF
--- a/default_test.go
+++ b/default_test.go
@@ -15,12 +15,12 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkEvent/1x1-8         	21140456	        61.46 ns/op	  16270375 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/1x10-8        	 2968579	       404.6 ns/op	  24713378 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/1x100-8       	  333204	      3591 ns/op	  27848968 ev/s	      15 B/op	       0 allocs/op
-BenchmarkEvent/10x1-8        	  685381	      1776 ns/op	   5630000 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x10-8       	  115762	     12810 ns/op	   7806533 ev/s	       3 B/op	       0 allocs/op
-BenchmarkEvent/10x100-8      	   28773	     48305 ns/op	  20700046 ev/s	     239 B/op	       0 allocs/op
+BenchmarkEvent/1x1-8         	22845045	        48.90 ns/op	  20399340 ev/s	       1 B/op	       0 allocs/op
+BenchmarkEvent/1x10-8        	 5448380	       212.2 ns/op	  46183805 ev/s	      47 B/op	       0 allocs/op
+BenchmarkEvent/1x100-8       	  631585	      1876 ns/op	  50592945 ev/s	     377 B/op	       0 allocs/op
+BenchmarkEvent/10x1-8        	 2284117	       503.2 ns/op	  19805320 ev/s	      11 B/op	       0 allocs/op
+BenchmarkEvent/10x10-8       	  521727	      2041 ns/op	  47717331 ev/s	     373 B/op	       0 allocs/op
+BenchmarkEvent/10x100-8      	   68062	     17626 ns/op	  55497296 ev/s	    2707 B/op	       0 allocs/op
 */
 func BenchmarkEvent(b *testing.B) {
 	for _, topics := range []int{1, 10} {

--- a/default_test.go
+++ b/default_test.go
@@ -15,12 +15,12 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkEvent/1x1-8         	18729601	        59.74 ns/op	  16739743 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x1-8        	  704184	      1749 ns/op	   5718222 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/1x10-8        	 2838696	       357.5 ns/op	  27975523 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x10-8       	  179293	     12922 ns/op	   7738928 ev/s	       1 B/op	       0 allocs/op
-BenchmarkEvent/1x100-8       	  249906	      4945 ns/op	  20223782 ev/s	       9 B/op	       0 allocs/op
-BenchmarkEvent/10x100-8      	   51558	     38953 ns/op	  25657300 ev/s	     257 B/op	       0 allocs/op
+BenchmarkEvent/1x1-8         	19471857	        61.37 ns/op	  16295560 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x1-8        	  701856	      1772 ns/op	   5643499 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/1x10-8        	 4033690	       389.9 ns/op	  25646847 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x10-8       	  107130	     12355 ns/op	   8093423 ev/s	       2 B/op	       0 allocs/op
+BenchmarkEvent/1x100-8       	  378753	      3680 ns/op	  27177107 ev/s	      16 B/op	       0 allocs/op
+BenchmarkEvent/10x100-8      	   28020	     46035 ns/op	  21738149 ev/s	     308 B/op	       0 allocs/op
 */
 func BenchmarkEvent(b *testing.B) {
 	for _, subs := range []int{1, 10, 100} {

--- a/default_test.go
+++ b/default_test.go
@@ -15,16 +15,16 @@ import (
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkEvent/1x1-8         	19471857	        61.37 ns/op	  16295560 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x1-8        	  701856	      1772 ns/op	   5643499 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/1x10-8        	 4033690	       389.9 ns/op	  25646847 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x10-8       	  107130	     12355 ns/op	   8093423 ev/s	       2 B/op	       0 allocs/op
-BenchmarkEvent/1x100-8       	  378753	      3680 ns/op	  27177107 ev/s	      16 B/op	       0 allocs/op
-BenchmarkEvent/10x100-8      	   28020	     46035 ns/op	  21738149 ev/s	     308 B/op	       0 allocs/op
+BenchmarkEvent/1x1-8         	21140456	        61.46 ns/op	  16270375 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/1x10-8        	 2968579	       404.6 ns/op	  24713378 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/1x100-8       	  333204	      3591 ns/op	  27848968 ev/s	      15 B/op	       0 allocs/op
+BenchmarkEvent/10x1-8        	  685381	      1776 ns/op	   5630000 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x10-8       	  115762	     12810 ns/op	   7806533 ev/s	       3 B/op	       0 allocs/op
+BenchmarkEvent/10x100-8      	   28773	     48305 ns/op	  20700046 ev/s	     239 B/op	       0 allocs/op
 */
 func BenchmarkEvent(b *testing.B) {
-	for _, subs := range []int{1, 10, 100} {
-		for _, topics := range []int{1, 10} {
+	for _, topics := range []int{1, 10} {
+		for _, subs := range []int{1, 10, 100} {
 			b.Run(fmt.Sprintf("%dx%d", topics, subs), func(b *testing.B) {
 				var count atomic.Int64
 				for i := 0; i < subs; i++ {

--- a/default_test.go
+++ b/default_test.go
@@ -28,7 +28,7 @@ func BenchmarkEvent(b *testing.B) {
 			b.Run(fmt.Sprintf("%dx%d", topics, subs), func(b *testing.B) {
 				var count atomic.Int64
 				for i := 0; i < subs; i++ {
-					for id := 0; id < topics; id++ {
+					for id := 10; id < 10+topics; id++ {
 						defer OnType(uint32(id), func(ev MyEvent3) {
 							count.Add(1)
 						})()
@@ -39,7 +39,7 @@ func BenchmarkEvent(b *testing.B) {
 				b.ReportAllocs()
 				b.ResetTimer()
 				for n := 0; n < b.N; n++ {
-					for id := 0; id < topics; id++ {
+					for id := 10; id < 10+topics; id++ {
 						Emit(MyEvent3{ID: id})
 					}
 				}

--- a/default_test.go
+++ b/default_test.go
@@ -8,33 +8,47 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkDefault/1-consumers-8         	 9965634	       120.6 ns/op	   9965601 msg	       0 B/op	       0 allocs/op
-BenchmarkDefault/10-consumers-8        	  800031	      1365 ns/op	   8000305 msg	       0 B/op	       0 allocs/op
-BenchmarkDefault/100-consumers-8       	   82742	     15891 ns/op	   8274183 msg	       0 B/op	       0 allocs/op
+BenchmarkEvent/1x1-8         	18729601	        59.74 ns/op	  16739743 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x1-8        	  704184	      1749 ns/op	   5718222 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/1x10-8        	 2838696	       357.5 ns/op	  27975523 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x10-8       	  179293	     12922 ns/op	   7738928 ev/s	       1 B/op	       0 allocs/op
+BenchmarkEvent/1x100-8       	  249906	      4945 ns/op	  20223782 ev/s	       9 B/op	       0 allocs/op
+BenchmarkEvent/10x100-8      	   51558	     38953 ns/op	  25657300 ev/s	     257 B/op	       0 allocs/op
 */
-func BenchmarkDefault(b *testing.B) {
+func BenchmarkEvent(b *testing.B) {
 	for _, subs := range []int{1, 10, 100} {
-		b.Run(fmt.Sprintf("%d-consumers", subs), func(b *testing.B) {
-			var count uint64
-			for i := 0; i < subs; i++ {
-				defer On(func(ev MyEvent1) {
-					atomic.AddUint64(&count, 1)
-				})()
-			}
+		for _, topics := range []int{1, 10} {
+			b.Run(fmt.Sprintf("%dx%d", topics, subs), func(b *testing.B) {
+				var count atomic.Int64
+				for i := 0; i < subs; i++ {
+					for id := 0; id < topics; id++ {
+						defer OnType(uint32(id), func(ev MyEvent3) {
+							count.Add(1)
+						})()
+					}
+				}
 
-			b.ReportAllocs()
-			b.ResetTimer()
-			for n := 0; n < b.N; n++ {
-				Emit(MyEvent1{})
-			}
-			b.ReportMetric(float64(count), "msg")
-		})
+				start := time.Now()
+				b.ReportAllocs()
+				b.ResetTimer()
+				for n := 0; n < b.N; n++ {
+					for id := 0; id < topics; id++ {
+						Emit(MyEvent3{ID: id})
+					}
+				}
+
+				elapsed := time.Since(start)
+				rate := float64(count.Load()) / elapsed.Seconds()
+				b.ReportMetric(rate, "ev/s")
+			})
+		}
 	}
 }
 

--- a/event_test.go
+++ b/event_test.go
@@ -16,21 +16,22 @@ func TestPublish(t *testing.T) {
 	d := NewDispatcher()
 	var wg sync.WaitGroup
 
-	// Subscribe
+	// Subscribe, must be received in order
 	var count int64
 	defer Subscribe(d, func(ev MyEvent1) {
-		atomic.AddInt64(&count, 1)
+		assert.Equal(t, int(atomic.AddInt64(&count, 1)), ev.Number)
 		wg.Done()
 	})()
 
 	// Publish
-	wg.Add(2)
-	Publish(d, MyEvent1{})
-	Publish(d, MyEvent1{})
+	wg.Add(3)
+	Publish(d, MyEvent1{Number: 1})
+	Publish(d, MyEvent1{Number: 2})
+	Publish(d, MyEvent1{Number: 3})
 
 	// Wait and check
 	wg.Wait()
-	assert.Equal(t, int64(2), count)
+	assert.Equal(t, int64(3), count)
 }
 
 func TestUnsubscribe(t *testing.T) {

--- a/event_test.go
+++ b/event_test.go
@@ -90,6 +90,16 @@ func TestPublishDifferentType(t *testing.T) {
 	})
 }
 
+func TestCloseDispatcher(t *testing.T) {
+	d := NewDispatcher()
+	defer SubscribeTo(d, TypeEvent1, func(ev MyEvent2) {})()
+
+	assert.NoError(t, d.Close())
+	assert.Panics(t, func() {
+		SubscribeTo(d, TypeEvent1, func(ev MyEvent2) {})
+	})
+}
+
 func TestMatrix(t *testing.T) {
 	const amount = 1000
 	for _, subs := range []int{1, 10, 100} {

--- a/event_test.go
+++ b/event_test.go
@@ -8,18 +8,19 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 /*
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkEvent/1x1-8         	23700472	        54.79 ns/op	  23700403 ev	         1.000 ev/op	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x1-8        	  749990	      1697 ns/op	   7499457 ev	         9.999 ev/op	       0 B/op	       0 allocs/op
-BenchmarkEvent/1x10-8        	 2860024	       417.6 ns/op	  28599542 ev	        10.00 ev/op	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x10-8       	  100000	     13270 ns/op	   9999952 ev	       100.0 ev/op	       1 B/op	       0 allocs/op
-BenchmarkEvent/1x100-8       	  226356	      5612 ns/op	  22634862 ev	       100.0 ev/op	       3 B/op	       0 allocs/op
-BenchmarkEvent/10x100-8      	   61760	     39021 ns/op	  61758698 ev	      1000 ev/op	      36 B/op	       0 allocs/op
+BenchmarkEvent/1x1-8         	23606526	        55.70 ns/op	  17952620 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x1-8        	  750093	      1677 ns/op	   5963737 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/1x10-8        	 2992201	       398.1 ns/op	  25120369 ev/s	       0 B/op	       0 allocs/op
+BenchmarkEvent/10x10-8       	  102986	     12018 ns/op	   8320753 ev/s	       1 B/op	       0 allocs/op
+BenchmarkEvent/1x100-8       	  247375	      5470 ns/op	  18279493 ev/s	      13 B/op	       0 allocs/op
+BenchmarkEvent/10x100-8      	   57990	     42819 ns/op	  23353052 ev/s	     209 B/op	       0 allocs/op
 */
 func BenchmarkEvent(b *testing.B) {
 	for _, subs := range []int{1, 10, 100} {
@@ -35,6 +36,7 @@ func BenchmarkEvent(b *testing.B) {
 					}
 				}
 
+				start := time.Now()
 				b.ReportAllocs()
 				b.ResetTimer()
 				for n := 0; n < b.N; n++ {
@@ -43,9 +45,9 @@ func BenchmarkEvent(b *testing.B) {
 					}
 				}
 
-				messages := float64(count.Load())
-				b.ReportMetric(messages, "ev")
-				b.ReportMetric(messages/float64(b.N), "ev/op")
+				elapsed := time.Since(start)
+				rate := float64(count.Load()) / elapsed.Seconds()
+				b.ReportMetric(rate, "ev/s")
 			})
 		}
 	}

--- a/event_test.go
+++ b/event_test.go
@@ -8,50 +8,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-/*
-cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkEvent/1x1-8         	23606526	        55.70 ns/op	  17952620 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x1-8        	  750093	      1677 ns/op	   5963737 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/1x10-8        	 2992201	       398.1 ns/op	  25120369 ev/s	       0 B/op	       0 allocs/op
-BenchmarkEvent/10x10-8       	  102986	     12018 ns/op	   8320753 ev/s	       1 B/op	       0 allocs/op
-BenchmarkEvent/1x100-8       	  247375	      5470 ns/op	  18279493 ev/s	      13 B/op	       0 allocs/op
-BenchmarkEvent/10x100-8      	   57990	     42819 ns/op	  23353052 ev/s	     209 B/op	       0 allocs/op
-*/
-func BenchmarkEvent(b *testing.B) {
-	for _, subs := range []int{1, 10, 100} {
-		for _, topics := range []int{1, 10} {
-			b.Run(fmt.Sprintf("%dx%d", topics, subs), func(b *testing.B) {
-				var count atomic.Int64
-				d := NewDispatcher()
-				for i := 0; i < subs; i++ {
-					for id := 0; id < topics; id++ {
-						defer SubscribeTo(d, uint32(id), func(ev MyEvent3) {
-							count.Add(1)
-						})()
-					}
-				}
-
-				start := time.Now()
-				b.ReportAllocs()
-				b.ResetTimer()
-				for n := 0; n < b.N; n++ {
-					for id := 0; id < topics; id++ {
-						Publish(d, MyEvent3{ID: id})
-					}
-				}
-
-				elapsed := time.Since(start)
-				rate := float64(count.Load()) / elapsed.Seconds()
-				b.ReportMetric(rate, "ev/s")
-			})
-		}
-	}
-}
 
 func TestPublish(t *testing.T) {
 	d := NewDispatcher()


### PR DESCRIPTION
This PR removes the usage of channel for broadcast and instead makes use of `sync.Cond` primitive directly. Subscribers are also flushed periodically to avoid lock contention. This results in ~2-4x performance improvement depending on the conditions.

## Before

```
cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
BenchmarkEvent/1x1-8            21888343               109.0 ns/op         9175415 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/1x10-8            3311071               724.4 ns/op        13803201 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/1x100-8            514850              4750 ns/op          21049985 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/10x1-8            2458360               975.9 ns/op        10245150 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/10x10-8            447559              5236 ns/op          19085895 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/10x100-8            30741             82802 ns/op          12080138 ev/s       14 B/op          0 allocs/op
```

## After
```
BenchmarkEvent/1x1-8            69634809                38.07 ns/op       26245794 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/1x10-8           15903538               188.2 ns/op        53029988 ev/s       10 B/op          0 allocs/op
BenchmarkEvent/1x100-8           1345704              1679 ns/op          59502067 ev/s       68 B/op          0 allocs/op
BenchmarkEvent/10x1-8            6537975               504.9 ns/op        19796366 ev/s        0 B/op          0 allocs/op
BenchmarkEvent/10x10-8           1740412              1979 ns/op          50472108 ev/s       87 B/op          0 allocs/op
BenchmarkEvent/10x100-8           160111             17376 ns/op          57290578 ev/s     2616 B/op          0 allocs/op
```