### PR TITLE
Introduce NewDispatcherConfig with configurable flush interval and max queue size

### DIFF
--- a/event.go
+++ b/event.go
@@ -38,10 +38,18 @@ type Dispatcher struct {
 
 // NewDispatcher creates a new dispatcher of events.
 func NewDispatcher() *Dispatcher {
+	return NewDispatcherConfig(
+		500*time.Microsecond,
+		50000,
+	)
+}
+
+// NewDispatcherConfig creates a new dispatcher with configurable flush interval and max queue size
+func NewDispatcherConfig(flushInterval time.Duration, maxQueue int) *Dispatcher {
 	d := &Dispatcher{
-		df:       500 * time.Microsecond,
+		df:       flushInterval,
 		done:     make(chan struct{}),
-		maxQueue: 50000, // 50k * 20 (df) = 1 million events / second
+		maxQueue: maxQueue,
 	}
 
 	d.subs.Store(&registry{


### PR DESCRIPTION
The default settings for Dispatcher causes high CPU usage due to it flushing every 500 microseconds. Not all projects require this level of performance. 

This PR introduces NewDispatcherConfig which allows configuration of the flush interval and queue size. This way dependant projects can tune for performance and CPU utilization. 